### PR TITLE
Adding UnitTests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9
+current_version = 0.1.10
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,5 @@
+[bumpversion]
+current_version = 0.1.9
+commit = True
+tag = True
+tag_name = v{new_version}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,0 +1,27 @@
+name: Run unit tests
+
+on:
+  pull_request:
+    # Pattern matched against refs/tags
+    tags:
+      - 'opened'
+      - 'reopened'
+      - 'edited'
+
+jobs:
+ run-unit-tests:
+   runs-on: ubuntu-latest
+   container:
+     image: docker.io/dataloopai/py3.8.node16:1.74.14
+   steps:
+     - name: Install dependencies
+       run: |
+         pip3 install dtlpy --upgrade
+         pip3 install -r requirements.txt
+     - name: Run tests
+       env:
+         PROJECT_ID: "${{ secrets.PROJECT_ID }}"
+         BOT_EMAIL: "${{ secrets.BOT_EMAIL }}"
+         BOT_PWD: "${{ secrets.BOT_PWD }}"
+       run: |
+         python3 -m unittest tests.test_models

--- a/creation.py
+++ b/creation.py
@@ -3,7 +3,7 @@ import dtlpy as dl
 from model_adapter import ModelAdapter
 
 
-def package_creation(project: dl.Project) -> dl.Package:
+def package_creation(project: dl.Project, entry_point_path: str = 'model_adapter.py') -> dl.Package:
     metadata = dl.Package.get_ml_metadata(cls=ModelAdapter,
                                           default_configuration={'weights_filename': 'huggingface.pt',
                                                                  'epochs': 10,
@@ -11,7 +11,7 @@ def package_creation(project: dl.Project) -> dl.Package:
                                                                  'top_k': 5,
                                                                  'device': 'cuda:0'}
                                           )
-    modules = dl.PackageModule.from_entry_point(entry_point='model_adapter.py')
+    modules = dl.PackageModule.from_entry_point(entry_point=entry_point_path)
     package = project.packages.push(package_name='hugging-face',
                                     ignore_sanity_check=True,
                                     src_path=os.getcwd(),

--- a/creation.py
+++ b/creation.py
@@ -15,8 +15,11 @@ def package_creation(project: dl.Project) -> dl.Package:
     package = project.packages.push(package_name='hugging-face',
                                     ignore_sanity_check=True,
                                     src_path=os.getcwd(),
+                                    is_global=True,
                                     package_type='ml',
                                     modules=[modules],
+                                    codebase=dl.GitCodebase(git_url='https://github.com/dataloop-ai-apps/huggingface-adapter.git',
+                                                            git_tag='v0.1.9'),
                                     service_config={
                                         'runtime': dl.KubernetesRuntime(pod_type=dl.INSTANCE_CATALOG_GPU_K80_S,
                                                                         autoscaler=dl.KubernetesRabbitmqAutoscaler(
@@ -30,6 +33,6 @@ def package_creation(project: dl.Project) -> dl.Package:
 
 if __name__ == "__main__":
     env = 'prod'
-    project_id = "<insert-project-id>"
+    project_id = "d7ac8ef8-aaa0-47de-a800-db5ae58ff917"
     dl.setenv(env)
     package = package_creation(dl.projects.get(project_id=project_id))

--- a/models/dialogpt-large.py
+++ b/models/dialogpt-large.py
@@ -67,7 +67,7 @@ def model_creation(package: dl.Package):
                                   tags=['llm', 'pretrained', "hugging-face"],
                                   dataset_id=None,
                                   status='trained',
-                                  scope='project',
+                                  scope='public',
                                   configuration={
                                       'weights_filename': 'dialogpt.pt',
                                       "module_name": "models.dialogpt-large",

--- a/models/dialogpt_large.py
+++ b/models/dialogpt_large.py
@@ -70,7 +70,7 @@ def model_creation(package: dl.Package):
                                   scope='public',
                                   configuration={
                                       'weights_filename': 'dialogpt.pt',
-                                      "module_name": "models.dialogpt-large",
+                                      "module_name": "models.dialogpt_large",
                                       'device': 'cuda:0'},
                                   project_id=package.project.id
                                   )

--- a/models/dslim_bert_base_ner.py
+++ b/models/dslim_bert_base_ner.py
@@ -4,7 +4,8 @@ import dtlpy as dl
 
 
 class HuggingAdapter:
-    def __init__(self, configuration):
+    def __init__(self, configuration=None):
+        self.configuration = configuration if configuration else {}
         self.tokenizer = AutoTokenizer.from_pretrained("dslim/bert-base-NER")
         self.model = AutoModelForTokenClassification.from_pretrained("dslim/bert-base-NER")
         self.nlp = pipeline("ner", model=self.model, tokenizer=self.tokenizer)
@@ -26,9 +27,7 @@ class HuggingAdapter:
         return batch_annotations
 
 
-def create_model_entity():
-    package = dl.packages.get(package_name='hugging-face')
-    project = dl.projects.get(project_name='Hugging Face')
+def create_model_entity(package: dl.Package) -> dl.Model:
     hugging = HuggingAdapter()
     id2label = hugging.model.config.id2label
     model = package.models.create(model_name='dslim/bert-base-NER',
@@ -41,8 +40,9 @@ def create_model_entity():
                                   configuration={'module_name': 'models.dslim_bert_base_ner',
                                                  'id_to_label_map': id2label,
                                                  'label_to_id_map': {v:k for k,v in id2label.items()}},
-                                  project_id=project.id
+                                  project_id=package.project.id
                                   )
+    return model
 
 
 def script():

--- a/models/facebook_detr_resnet_101.py
+++ b/models/facebook_detr_resnet_101.py
@@ -45,10 +45,8 @@ class HuggingAdapter:
         return processed_outputs[0]
 
 
-def create_model_entity():
-    package = dl.packages.get(package_name='hugging-face')
-    project = dl.projects.get(project_name='Hugging Face')
-    hugging = HuggingAdapter()
+def create_model_entity(package: dl.Package) -> dl.Model:
+    hugging = HuggingAdapter({})
     id2label = hugging.model.config.id2label
     model = package.models.create(model_name='facebook/detr-resnet-101',
                                   description='facebook/detr-resnet-101',
@@ -57,9 +55,10 @@ def create_model_entity():
                                   scope='project',
                                   status='trained',
                                   labels=list(id2label.values()),
-                                  configuration={'module_name': 'models.facebook.detr_resnet_101',
+                                  configuration={'module_name': 'models.facebook_detr_resnet_101',
                                                  'id_to_label_map': id2label,
                                                  'label_to_id_map': {v: k for k, v in id2label.items()}},
-                                  project_id=project.id,
+                                  project_id=package.project.id,
 
                                   )
+    return model

--- a/models/facebook_detr_resnet_50_panoptic.py
+++ b/models/facebook_detr_resnet_50_panoptic.py
@@ -1,10 +1,10 @@
 import dtlpy as dl
 import torch
-import numpy
+import numpy as np
 import io
 
 from transformers import DetrFeatureExtractor, DetrForSegmentation
-from transformers.models.detr.feature_extraction_detr import rgb_to_id
+from PIL import Image
 
 
 class HuggingAdapter:
@@ -33,6 +33,14 @@ class HuggingAdapter:
                     batch_annotations.append(collection)
         return batch_annotations
 
+    @staticmethod
+    def rgb_to_id(color):
+        if isinstance(color, np.ndarray) and len(color.shape) == 3:
+            if color.dtype == np.uint8:
+                color = color.astype(np.int32)
+            return color[:, :, 0] + 256 * color[:, :, 1] + 256 * 256 * color[:, :, 2]
+        return int(color[0] + 256 * color[1] + 256 * 256 * color[2])
+
     def make_prediction(self, image):
 
         # prepare image for the model
@@ -45,16 +53,14 @@ class HuggingAdapter:
         processed_sizes = torch.as_tensor(inputs["pixel_values"].shape[-2:]).unsqueeze(0)
         result = self.feature_extractor.post_process_panoptic(outputs, processed_sizes)[0]
         panoptic_seg = Image.open(io.BytesIO(result["png_string"]))
-        panoptic_seg = numpy.array(panoptic_seg, dtype=numpy.uint8)
+        panoptic_seg = np.array(panoptic_seg, dtype=np.uint8)
         # retrieve the ids corresponding to each mask
-        panoptic_seg_id = rgb_to_id(panoptic_seg)
+        panoptic_seg_id = self.rgb_to_id(panoptic_seg)
         return panoptic_seg_id
 
 
-def create_model_entity():
-    package = dl.packages.get(package_name='hugging-face')
-    project = dl.projects.get(project_name='Hugging Face')
-    hugging = HuggingAdapter()
+def create_model_entity(package: dl.Package) -> dl.Model:
+    hugging = HuggingAdapter({})
     id2label = hugging.model.config.id2label
     model = package.models.create(model_name='facebook/detr-resnet-50-panoptic',
                                   description='facebook/detr-resnet-50-panoptic',
@@ -66,8 +72,9 @@ def create_model_entity():
                                   configuration={'module_name': 'models.facebook_detr_resnet_50_panoptic',
                                                  'id_to_label_map': id2label,
                                                  'label_to_id_map': {v: k for k, v in id2label.items()}},
-                                  project_id=project.id
+                                  project_id=package.project.id
                                   )
+    return model
 
 
 def script():
@@ -94,8 +101,8 @@ def script():
 
     # the segmentation is stored in a special-format png
     panoptic_seg = Image.open(io.BytesIO(result["png_string"]))
-    panoptic_seg = numpy.array(panoptic_seg, dtype=numpy.uint8)
+    panoptic_seg = np.array(panoptic_seg, dtype=np.uint8)
     # retrieve the ids corresponding to each mask
-    panoptic_seg_id = rgb_to_id(panoptic_seg)
+    panoptic_seg_id = hugging.rgb_to_id(panoptic_seg)
     plt.figure()
     plt.imshow(panoptic_seg_id)

--- a/models/open_llama.py
+++ b/models/open_llama.py
@@ -59,7 +59,7 @@ def model_creation(package: dl.Package):
                                   tags=['llm', 'pretrained', "hugging-face"],
                                   dataset_id=None,
                                   status='trained',
-                                  scope='project',
+                                  scope='public',
                                   configuration={
                                       'weights_filename': 'openllama.pt',
                                       'model_path': 'openlm-research/open_llama_3b',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Pillow
 requests
 transformers==4.30.2
+dtlpy
 timm
 sentencepiece
 accelerate==0.20.3

--- a/tests/test_input.json
+++ b/tests/test_input.json
@@ -1,0 +1,14 @@
+{
+  "shebang": "dataloop",
+  "metadata": {
+    "dltype": "prompt"
+  },
+  "prompts": {
+    "prompt1": {
+      "question-1": {
+        "mimetype": "application/text",
+        "value": "Is this a test?"
+      }
+    }
+  }
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ class MyTestCase(unittest.TestCase):
             dl.login()
         try:
             cls.project = dl.projects.create("hugging_face_adapter_tests")
-        except dl.exceptions.Conflict:
+        except dl.exceptions.InternalServerError:
             print("Dummy project already exists")
             cls.project = dl.projects.get("hugging_face_adapter_tests")
         cls.package = package_creation(cls.project, "../model_adapter.py")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,9 @@
 import unittest
 import dtlpy as dl
+import json
+import random
+import torch
+import numpy as np
 from models import (open_llama, dialogpt_large, dslim_bert_base_ner, facebook_detr_resnet_50_panoptic,
                     facebook_detr_resnet_101)
 from creation import package_creation
@@ -8,34 +12,74 @@ from transformers import (GPT2LMHeadModel, GPT2TokenizerFast, LlamaTokenizer, Ll
                           BertForTokenClassification, BertTokenizerFast, DetrForSegmentation, DetrFeatureExtractor,
                           DetrForObjectDetection)
 
-TOKEN = '<INSERT-TOKEN-MECHANISM>'
+SEED = 1337
+random.seed(SEED)
+np.random.seed(SEED)
+torch.manual_seed(SEED)
 
 
 class MyTestCase(unittest.TestCase):
+    project: dl.Project = None
+    package: dl.Package = None
 
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(SEED)
         if dl.token_expired():
-            dl.login_token(TOKEN)
-        self.project = dl.projects.create("hugging_face_adapter_tests")
-        self.package = package_creation(self.project, "../model_adapter.py")
+            dl.login()
+        try:
+            cls.project = dl.projects.create("hugging_face_adapter_tests")
+        except dl.exceptions.Conflict:
+            print("Dummy project already exists")
+            cls.project = dl.projects.get("hugging_face_adapter_tests")
+        cls.package = package_creation(cls.project, "../model_adapter.py")
 
-    def tearDown(self) -> None:
-        self.project.delete(sure=True, really=True)
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.project.delete(sure=True, really=True)
         dl.logout()
 
     def test_open_llama(self):
+        random.seed(SEED)
+        np.random.seed(SEED)
+        torch.manual_seed(SEED)
         model = open_llama.model_creation(self.package)
         model_adapter = ModelAdapter(model)
+        model_adapter.hugging.model.config.seed = SEED
+        with open("./test_input.json", "r") as f:
+            inp = json.load(f)
+        ans = model_adapter.predict([inp])
         self.assertTrue(isinstance(model_adapter.hugging.model, LlamaForCausalLM))
         self.assertTrue(isinstance(model_adapter.hugging.tokenizer, LlamaTokenizer))
         self.assertTrue('open_llama' in model_adapter.hugging.model.name_or_path.lower())
+        self.assertEqual(
+            ans[0][0]['coordinates'],
+            "I'm not sure if this is a test or not.\nI'm not sure if this is a test or not. I'm not sure if this is a test or not. I'm not sure if this is a test or not. I'm not sure if this is a test or not. I'm not sure if this is a test or not. I'm not sure if this is a test or not. I"
+            )
+        self.assertAlmostEqual(
+            ans[0][0]['metadata']['user']['model']['confidence'],
+            0.7106203436851501, 3
+            )
 
     def test_dialogpt(self):
         model = dialogpt_large.model_creation(self.package)
         model_adapter = ModelAdapter(model)
+        model_adapter.hugging.model.config.seed = SEED
+        with open("./test_input.json", "r") as f:
+            inp = json.load(f)
+        ans = model_adapter.predict([inp])
         self.assertTrue(isinstance(model_adapter.hugging.model, GPT2LMHeadModel))
         self.assertTrue(isinstance(model_adapter.hugging.tokenizer, GPT2TokenizerFast))
         self.assertTrue('dialogpt' in model_adapter.hugging.model.name_or_path.lower())
+        self.assertEqual(
+            ans[0][0]['coordinates'],
+            "It's a test of our faith."
+            )
+        self.assertAlmostEqual(
+            ans[0][0]['metadata']['user']['model']['confidence'],
+            0.3476366400718689, 3
+            )
 
     def test_bert_base(self):
         model = dslim_bert_base_ner.create_model_entity(self.package)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,63 @@
+import unittest
+import dtlpy as dl
+from models import (open_llama, dialogpt_large, dslim_bert_base_ner, facebook_detr_resnet_50_panoptic,
+                    facebook_detr_resnet_101)
+from creation import package_creation
+from model_adapter import ModelAdapter
+from transformers import (GPT2LMHeadModel, GPT2TokenizerFast, LlamaTokenizer, LlamaForCausalLM,
+                          BertForTokenClassification, BertTokenizerFast, DetrForSegmentation, DetrFeatureExtractor,
+                          DetrForObjectDetection)
+
+TOKEN = '<INSERT-TOKEN-MECHANISM>'
+
+
+class MyTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if dl.token_expired():
+            dl.login_token(TOKEN)
+        self.project = dl.projects.create("hugging_face_adapter_tests")
+        self.package = package_creation(self.project, "../model_adapter.py")
+
+    def tearDown(self) -> None:
+        self.project.delete(sure=True, really=True)
+        dl.logout()
+
+    def test_open_llama(self):
+        model = open_llama.model_creation(self.package)
+        model_adapter = ModelAdapter(model)
+        self.assertTrue(isinstance(model_adapter.hugging.model, LlamaForCausalLM))
+        self.assertTrue(isinstance(model_adapter.hugging.tokenizer, LlamaTokenizer))
+        self.assertTrue('open_llama' in model_adapter.hugging.model.name_or_path.lower())
+
+    def test_dialogpt(self):
+        model = dialogpt_large.model_creation(self.package)
+        model_adapter = ModelAdapter(model)
+        self.assertTrue(isinstance(model_adapter.hugging.model, GPT2LMHeadModel))
+        self.assertTrue(isinstance(model_adapter.hugging.tokenizer, GPT2TokenizerFast))
+        self.assertTrue('dialogpt' in model_adapter.hugging.model.name_or_path.lower())
+
+    def test_bert_base(self):
+        model = dslim_bert_base_ner.create_model_entity(self.package)
+        model_adapter = ModelAdapter(model)
+        self.assertTrue(isinstance(model_adapter.hugging.model, BertForTokenClassification))
+        self.assertTrue(isinstance(model_adapter.hugging.tokenizer, BertTokenizerFast))
+        self.assertTrue('bert-base' in model_adapter.hugging.model.name_or_path.lower())
+
+    def test_detr_resnet_50_panoptic(self):
+        model = facebook_detr_resnet_50_panoptic.create_model_entity(self.package)
+        model_adapter = ModelAdapter(model)
+        self.assertTrue(isinstance(model_adapter.hugging.model, DetrForSegmentation))
+        self.assertTrue(isinstance(model_adapter.hugging.feature_extractor, DetrFeatureExtractor))
+        self.assertTrue('detr-resnet-50-panoptic' in model_adapter.hugging.model.name_or_path.lower())
+
+    def test_detr_resnet_101(self):
+        model = facebook_detr_resnet_101.create_model_entity(self.package)
+        model_adapter = ModelAdapter(model)
+        self.assertTrue(isinstance(model_adapter.hugging.model, DetrForObjectDetection))
+        self.assertTrue(isinstance(model_adapter.hugging.feature_extractor, DetrFeatureExtractor))
+        self.assertTrue('detr-resnet-101' in model_adapter.hugging.model.name_or_path.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding unittests for all the currently available HuggingAdapters, along with a structure for future models unittest.

Currently, it:

1. logins
2. creates temp project
3. creates hugging face adapter in temp project
4. tests create a model
5. instantiate model_adapter
6. check if model has right class, tokenizer/feat_extractor/name
7. delete the temp project
8. logout

Still missing:
Better way to login to run unittests automatically via github, right now it's necessary to manually enter your token.