### PR TITLE
Create AutoCausalLM

### DIFF
--- a/creation.py
+++ b/creation.py
@@ -30,6 +30,6 @@ def package_creation(project: dl.Project) -> dl.Package:
 
 if __name__ == "__main__":
     env = 'prod'
-    project_id = "<insert-project-id>"
+    project_id = "0cf49805-927a-4067-b3de-a26dac993800"
     dl.setenv(env)
     package = package_creation(dl.projects.get(project_id=project_id))

--- a/creation.py
+++ b/creation.py
@@ -3,7 +3,7 @@ import dtlpy as dl
 from model_adapter import ModelAdapter
 
 
-def package_creation(project):
+def package_creation(project: dl.Project) -> dl.Package:
     metadata = dl.Package.get_ml_metadata(cls=ModelAdapter,
                                           default_configuration={'weights_filename': 'huggingface.pt',
                                                                  'epochs': 10,
@@ -15,11 +15,7 @@ def package_creation(project):
     package = project.packages.push(package_name='hugging-face',
                                     ignore_sanity_check=True,
                                     src_path=os.getcwd(),
-                                    # description='Global Dataloop ResNet implemented in pytorch',
-                                    # scope='public',
                                     package_type='ml',
-                                    # codebase=dl.GitCodebase(git_url='https://github.com/dataloop-ai/pytorch_adapters',
-                                    #                         git_tag='mgmt3'),
                                     modules=[modules],
                                     service_config={
                                         'runtime': dl.KubernetesRuntime(pod_type=dl.INSTANCE_CATALOG_GPU_K80_S,
@@ -28,17 +24,12 @@ def package_creation(project):
                                                                             max_replicas=1),
                                                                         concurrency=1).to_json()},
                                     metadata=metadata)
-    # s = package.services.list().items[0]
-    # s.package_revision = package.version
-    # s.versions['dtlpy'] = '1.63.2'
-    # s.update(True)
     print("Package created!")
     return package
 
 
 if __name__ == "__main__":
     env = 'prod'
-    project_id = "<project-id>"
+    project_id = "<insert-project-id>"
     dl.setenv(env)
-    project = dl.projects.get(project_id=project_id)
-    package = package_creation(project)
+    package = package_creation(dl.projects.get(project_id=project_id))

--- a/models/autocausallm.py
+++ b/models/autocausallm.py
@@ -7,8 +7,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 class HuggingAdapter:
     def __init__(self, configuration):
         self.model_name = configuration.get("model_name")
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, padding_side='left')
-        self.model = AutoModelForCausalLM.from_pretrained(configuration.get("tokenizer"))
+        trust_remote_code = configuration.get("trust_remote_code", False)
+        padding_side = configuration.get("padding_side", 'left')
+        self.tokenizer = AutoTokenizer.from_pretrained(configuration.get("tokenizer"), padding_side=padding_side)
+        self.model = AutoModelForCausalLM.from_pretrained(self.model_name, trust_remote_code=trust_remote_code)
         self.top_k = configuration.get("top_k", 5)
 
     def prepare_item_func(self, item: dl.Item):
@@ -62,7 +64,7 @@ class HuggingAdapter:
 
 
 def model_creation(package: dl.Package):
-    model = package.models.create(model_name='autocausallm-huggingface',
+    model = package.models.create(model_name='dolly-huggingface',
                                   description='Flexible autocausalLM adapter for HF models',
                                   tags=['llm', 'pretrained', "hugging-face"],
                                   dataset_id=None,
@@ -71,8 +73,8 @@ def model_creation(package: dl.Package):
                                   configuration={
                                       'weights_filename': 'dialogpt.pt',
                                       "module_name": "models.autocausallm",
-                                      "model_name": "microsoft/DialoGPT-large",
-                                      "tokenizer": "microsoft/DialoGPT-large",
+                                      "model_name": "databricks/dolly-v2-12b",
+                                      "tokenizer": "databricks/dolly-v2-12b",
                                       'device': 'cuda:0'},
                                   project_id=package.project.id
                                   )

--- a/models/autocausallm.py
+++ b/models/autocausallm.py
@@ -1,0 +1,80 @@
+import dtlpy as dl
+import torch
+import json
+import os
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class HuggingAdapter:
+    def __init__(self, configuration):
+        self.model_name = configuration.get("model_name")
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, padding_side='left')
+        self.model = AutoModelForCausalLM.from_pretrained(configuration.get("tokenizer"))
+        self.top_k = configuration.get("top_k", 5)
+
+    def prepare_item_func(self, item: dl.Item):
+        buffer = json.load(item.download(save_locally=False))
+        return buffer
+
+    def compute_confidence(self, input_ids):
+        logits = self.model(input_ids).logits[:, -1, :]
+        probs = torch.softmax(logits, dim=-1)
+        top_k_probs, top_k_indices = torch.topk(probs, k=self.top_k)
+        confidence_score = top_k_probs.sum().item()
+        return confidence_score
+
+    def train(self, data_path, output_path, **kwargs):
+        print("Training not implemented yet")
+
+    def predict(self, batch, **kwargs):
+        annotations = []
+        for item in batch:
+            prompts = item["prompts"]
+            item_annotations = []
+            for prompt_key, prompt_content in prompts.items():
+                chat_history_ids = torch.tensor([])
+                for question in prompt_content.values():
+                    print(f"User: {question['value']}")
+                    new_user_input_ids = self.tokenizer.encode(question["value"] + self.tokenizer.eos_token,
+                                                               return_tensors='pt')
+                    bot_input_ids = torch.cat([chat_history_ids, new_user_input_ids], dim=-1) \
+                        if len(chat_history_ids) else new_user_input_ids
+                    chat_history_ids = self.model.generate(bot_input_ids, max_new_tokens=1000, do_sample=True,
+                                                           pad_token_id=self.tokenizer.eos_token_id, top_k=self.top_k)
+                    response = self.tokenizer.decode(chat_history_ids[:, bot_input_ids.shape[-1]:][0],
+                                                     skip_special_tokens=True)
+                    print("Response: {}".format(response))
+                    item_annotations.append({
+                        "type": "text",
+                        "label": "q",
+                        "coordinates": response,
+                        "metadata": {
+                            "system": {"promptId": prompt_key},
+                            "user": {
+                                "annotation_type": "prediction",
+                                "model": {
+                                    "name": self.model_name,
+                                    "confidence": self.compute_confidence(new_user_input_ids)
+                                    }
+                                }}
+                        })
+            annotations.append(item_annotations)
+        return annotations
+
+
+def model_creation(package: dl.Package):
+    model = package.models.create(model_name='autocausallm-huggingface',
+                                  description='Flexible autocausalLM adapter for HF models',
+                                  tags=['llm', 'pretrained', "hugging-face"],
+                                  dataset_id=None,
+                                  status='trained',
+                                  scope='project',
+                                  configuration={
+                                      'weights_filename': 'dialogpt.pt',
+                                      "module_name": "models.autocausallm",
+                                      "model_name": "microsoft/DialoGPT-large",
+                                      "tokenizer": "microsoft/DialoGPT-large",
+                                      'device': 'cuda:0'},
+                                  project_id=package.project.id
+                                  )
+    return model

--- a/models/autocausallm.py
+++ b/models/autocausallm.py
@@ -1,7 +1,6 @@
 import dtlpy as dl
 import torch
 import json
-import os
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 

--- a/models/facebook_detr_resnet_50_panoptic.py
+++ b/models/facebook_detr_resnet_50_panoptic.py
@@ -101,8 +101,8 @@ def script():
 
     # the segmentation is stored in a special-format png
     panoptic_seg = Image.open(io.BytesIO(result["png_string"]))
-    panoptic_seg = numpy.array(panoptic_seg, dtype=numpy.uint8)
+    panoptic_seg = np.array(panoptic_seg, dtype=np.uint8)
     # retrieve the ids corresponding to each mask
-    panoptic_seg_id = rgb_to_id(panoptic_seg)
+    panoptic_seg_id = hugging.rgb_to_id(panoptic_seg)
     plt.figure()
     plt.imshow(panoptic_seg_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 requests
-transformers==4.30.2
+transformers
 timm
 sentencepiece
 accelerate==0.20.3


### PR DESCRIPTION
With the new HuggingAdapter added to this PR, it is a matter of adding "model_name" and "tokenizer" to a model configuration in order to use the AutoModelCausalLM and AutoTokenizer from HuggingFace. As long as the model card in HF states that these classes can be used, this model adapter should allow them to work in DL. Still, it would be better to test specific models before announcing them as available.