### PR TITLE
APPS 1558: add blip 2 model adapter

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -48,6 +48,10 @@ replace = "{new_version}"
 search = "{current_version}"
 replace = "{new_version}"
 
+[bumpversion:file:adapters/blip_2/dataloop.json]
+search = "{current_version}"
+replace = "{new_version}"
+
 [bumpversion:file:adapters/blip_image_captioning_large/dataloop.json]
 search = "{current_version}"
 replace = "{new_version}"

--- a/.dataloop.cfg
+++ b/.dataloop.cfg
@@ -9,6 +9,7 @@
     "adapters/vilt_b32_finetuned_vqa/dataloop.json",
     "adapters/vit_gpt2_image_captioning/dataloop.json",
     "adapters/uform_gen2_qwen_500m/dataloop.json",
+    "adapters/blip_2/dataloop.json",
     "adapters/blip_image_captioning_large/dataloop.json",
     "adapters/pegasus_summarize/dataloop.json",
     "adapters/amazon_review_sentiment_analysis/dataloop.json",

--- a/.gitignore
+++ b/.gitignore
@@ -289,6 +289,7 @@ pyvenv.cfg
 pip-selfcheck.json
 
 ### VisualStudioCode ###
+.vscode/
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM dataloopai/dtlpy-agent:gpu.cuda.11.8.devel.py3.8.pytorch2
+FROM dataloopai/dtlpy-agent:gpu.cuda.11.8.py3.10.pytorch2
 
 USER root
-RUN apt update && apt install -y ffmpeg
+RUN apt update && apt install -y ffmpeg rustc cargo
 
 USER 1000
 COPY requirements.txt /tmp/

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -1,0 +1,78 @@
+import json
+import torch
+import PIL
+import dtlpy as dl
+import logging
+from transformers import AutoProcessor, Blip2ForConditionalGeneration
+
+logger = logging.getLogger("[BLIP]")
+CAPTIONING_PROMPT = "Caption this image."
+
+
+class HuggingAdapter:
+    def __init__(self, configuration):
+        self.model_name = configuration.get("model_name")
+        self.device = configuration.get("device")
+        self.conditioning = configuration.get("conditioning", False)
+        self.processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
+        self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
+        self.model.to(self.device)
+
+    def prepare_item_func(self, item: dl.Item):
+        buffer = json.load(item.download(save_locally=False))
+        prompts = buffer["prompts"]
+        ready_prompts = []
+        for prompt_key, prompt_content in prompts.items():
+            questions = list(prompt_content.values()) if isinstance(prompt_content, dict) else prompt_content
+
+            image_buffer = None
+            prompt_text = None
+            prompt_image_found = False
+            prompt_text_found = not self.conditioning
+            for prompt_part in questions:
+                if "image" in prompt_part["mimetype"] and not prompt_image_found:
+                    image_url = prompt_part["value"]
+                    item_id = image_url.split("/stream")[0].split("/items/")[-1]
+                    item = dl.items.get(item_id=item_id)
+                    image_buffer = item.download(save_locally=False)
+                    prompt_image_found = True
+                elif "text" in prompt_part["mimetype"] and not prompt_text_found:
+                    prompt_text = prompt_part["value"]
+                    prompt_text_found = True
+                else:
+                    logger.warning(f"BLIP only accepts text and image prompts, "
+                                   f"ignoring the current prompt.")
+
+                # Break loop after all inputs received
+                if prompt_image_found and prompt_text_found:
+                    break
+
+            if prompt_image_found and prompt_text_found:
+                ready_prompts.append((prompt_key, image_buffer, prompt_text))
+            else:
+                raise ValueError(f"{prompt_key} is missing either an image or a text prompt.")
+
+        return ready_prompts
+
+    def train(self, data_path, output_path, **kwargs):
+        logger.info("Training not implemented yet")
+
+    def predict(self, batch: list[dl.Item], **kwargs):
+        annotations = []
+        for prompts in batch:
+            item_annotations = dl.AnnotationCollection()
+            for prompt_key, image_buffer, prompt_txt in prompts:
+                encoding = self.processor(PIL.Image.open(image_buffer), prompt_txt, return_tensors='pt').to(self.device)
+                output = self.model.generate(**encoding)
+                response = self.processor.decode(output[0], skip_special_tokens=True)
+                print("Response: {}".format(response))
+                item_annotations.add(
+                    annotation_definition=dl.FreeText(text=response),
+                    prompt_id=prompt_key,
+                    model_info={
+                        'name': self.model_name,
+                        'confidence': 1.0
+                        }
+                    )
+            annotations.append(item_annotations)
+        return annotations

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -17,7 +17,7 @@ class HuggingAdapter:
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model.to(self.device)
 
-    def prepare_item_func(item: dl.Item):
+    def prepare_item_func(self, item: dl.Item):
         prompt_item = dl.PromptItem.from_item(item)
         return prompt_item
 

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -1,6 +1,5 @@
 import base64
 from io import BytesIO
-import json
 from typing import List
 import PIL
 import dtlpy as dl

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -86,7 +86,6 @@ class HuggingAdapter(dl.BaseModelAdapter):
                 image_url = content.get("image_url", {}).get("url")
                 if image_url is not None:
                     if image_buffer is not None: # i.e., we previously found an image
-                        logger.error("Multiple images not supported, using only the first one")
                         raise ValueError("Multiple images not supported")
                     else:
                         base64_str = content["image_url"]["url"].split("base64,")[1]

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -26,14 +26,10 @@ class HuggingAdapter(dl.BaseModelAdapter):
             prompt_txt, image_buffer = HuggingAdapter.reformat_messages(
                 prompt_item.to_messages(model_name=self.model_name)
             )
-            if prompt_txt:
-                encoding = self.processor(
-                    PIL.Image.open(image_buffer).convert('RGB'), prompt_txt, return_tensors="pt"
-                ).to(self.device)
-            else:
-                encoding = self.processor(
-                    PIL.Image.open(image_buffer).convert('RGB'), return_tensors="pt"
-                ).to(self.device)
+            encoding = self.processor(
+                PIL.Image.open(image_buffer).convert('RGB'), prompt_txt, return_tensors="pt"
+            ).to(self.device)
+            
             output = self.model.generate(**encoding, max_new_tokens=50)
             response = self.processor.decode(
                 output[0], skip_special_tokens=True
@@ -47,7 +43,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
                 model_info={
                     "name": self.model_name,
                     "confidence": 1.0,
-                    "model_id": self.model_entity.id,
+                    "model_id": '1',
                 },
             )
         return []
@@ -97,12 +93,10 @@ class HuggingAdapter(dl.BaseModelAdapter):
             else:
                 raise ValueError(f"Unsupported content type: {content_type}")
         
-        if prompt_txt is not None:
-            prompt_txt = "Question: {} Answer:".format(prompt_txt)
-        else:
-            # If no text found, generates from the BOS token:
-            # https://github.com/NielsRogge/Transformers-Tutorials/blob/master/BLIP-2/Chat_with_BLIP_2.ipynb
-            logging.warning("No text found in messages, generating from the BOS (beginning-of-sequence) token.")
+        if prompt_txt is None:
+            prompt_txt = "What is in this image?"
+        prompt_txt = "Question: {} Answer:".format(prompt_txt)
+
         if not image_buffer:
             raise ValueError("No image found in messages.")
 

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -6,9 +6,7 @@ import dtlpy as dl
 import logging
 from transformers import AutoProcessor, Blip2ForConditionalGeneration
 
-logger = logging.getLogger("[BLIP]")
-CAPTIONING_PROMPT = "Caption this image."
-
+logger = logging.getLogger("[BLIP-2]")
 
 class HuggingAdapter:
     def __init__(self, configuration):

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -1,3 +1,5 @@
+import base64
+from io import BytesIO
 import json
 from typing import List
 import PIL
@@ -18,59 +20,50 @@ class HuggingAdapter:
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model.to(self.device)
 
-    def prepare_item_func(self, item: dl.Item):
-        buffer = json.load(item.download(save_locally=False))
-        prompts = buffer["prompts"]
-        ready_prompts = []
-        for prompt_key, prompt_content in prompts.items():
-            questions = list(prompt_content.values()) if isinstance(prompt_content, dict) else prompt_content
+    def prepare_item_func(item: dl.Item):
+        prompt_item = dl.PromptItem.from_item(item)
+        return prompt_item
 
-            image_buffer = None
-            prompt_text = None
-            prompt_image_found = False
-            prompt_text_found = not self.conditioning
-            for prompt_part in questions:
-                if "image" in prompt_part["mimetype"] and not prompt_image_found:
-                    image_url = prompt_part["value"]
-                    item_id = image_url.split("/stream")[0].split("/items/")[-1]
-                    item = dl.items.get(item_id=item_id)
-                    image_buffer = item.download(save_locally=False)
-                    prompt_image_found = True
-                elif "text" in prompt_part["mimetype"] and not prompt_text_found:
-                    prompt_text = prompt_part["value"]
-                    prompt_text_found = True
-                else:
-                    logger.warning("BLIP only accepts text and image prompts, "
-                                   "ignoring the current prompt.")
-
-                # Break loop after all inputs received
-                if prompt_image_found and prompt_text_found:
-                    break
-
-            if prompt_image_found and prompt_text_found:
-                ready_prompts.append((prompt_key, image_buffer, prompt_text))
-            else:
-                raise ValueError(f"{prompt_key} is missing either an image or a text prompt.")
-
-        return ready_prompts
-    
     def predict(self, batch: List[dl.Item], **kwargs):
-        annotations = []
-        for prompts in batch:
-            item_annotations = dl.AnnotationCollection()
-            for prompt_key, image_buffer, prompt_txt in prompts:
-                prompt = "Question: {} Answer:".format(prompt_txt)
-                encoding = self.processor(PIL.Image.open(image_buffer), prompt, return_tensors='pt').to(self.device)
-                output = self.model.generate(**encoding)
-                response = self.processor.decode(output[0], skip_special_tokens=True).strip()
-                print("Response: {}".format(response))
-                item_annotations.add(
-                    annotation_definition=dl.FreeText(text=response),
-                    prompt_id=prompt_key,
-                    model_info={
-                        'name': self.model_name,
-                        'confidence': 1.0
-                        }
-                    )
-            annotations.append(item_annotations)
-        return annotations
+        for prompt_item in batch:
+            prompt_txt, image_buffer = self.reformat_messages(
+                prompt_item.to_messages(model_name=self.model_name)
+            )
+            prompt = "Question: {} Answer:".format(prompt_txt)
+            encoding = self.processor(
+                PIL.Image.open(image_buffer), prompt, return_tensors="pt"
+            ).to(self.device)
+            output = self.model.generate(**encoding)
+            response = self.processor.decode(
+                output[0], skip_special_tokens=True
+            ).strip()
+            print("Response: {}".format(response))
+            prompt_item.add(
+                message={
+                    "role": "assistant",
+                    "content": [{"mimetype": dl.PromptType.TEXT, "value": response}],
+                },
+                model_info={
+                    "name": self.model_name,
+                    "confidence": 1.0,
+                    "model_id": self.model_entity.id,
+                },
+            )
+        return []
+
+    def reformat_messages(self, messages):
+        def get_last_user_message(messages):
+            for message in reversed(messages):
+                if message.get("role") == "user":
+                    return message
+            raise ValueError("No message with role 'user' found")
+
+        last_user_message = get_last_user_message(messages)
+        for content in last_user_message["content"]:
+            if content["type"] == "text":
+                prompt_txt = content["text"]
+            elif content["type"] == "image_url":
+                base64_str = content["image_url"]["url"].split("base64,")[1]
+                image_buffer = BytesIO(base64.b64decode(base64_str))
+
+        return prompt_txt, image_buffer

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -8,11 +8,11 @@ from transformers import AutoProcessor, Blip2ForConditionalGeneration
 
 logger = logging.getLogger("[BLIP-2]")
 
-class HuggingAdapter:
-    def __init__(self, configuration):
-        self.model_name = configuration.get("model_name", "blip-2")
-        self.device = configuration.get("device", "cpu")
-        self.conditioning = configuration.get("conditioning", False)
+class HuggingAdapter(dl.BaseModelAdapter):
+    def load(self, local_path, **kwargs):
+        self.model_name = self.configuration.get("model_name", "blip-2")
+        self.device = self.configuration.get("device", "cpu")
+        self.conditioning = self.configuration.get("conditioning", False)
         self.processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model.to(self.device)
@@ -21,7 +21,7 @@ class HuggingAdapter:
         prompt_item = dl.PromptItem.from_item(item)
         return prompt_item
 
-    def predict(self, batch: List[dl.Item], **kwargs):
+    def predict(self, batch: List[dl.PromptItem], **kwargs):
         for prompt_item in batch:
             prompt_txt, image_buffer = self.reformat_messages(
                 prompt_item.to_messages(model_name=self.model_name)

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -63,9 +63,10 @@ class HuggingAdapter:
         for prompts in batch:
             item_annotations = dl.AnnotationCollection()
             for prompt_key, image_buffer, prompt_txt in prompts:
-                encoding = self.processor(PIL.Image.open(image_buffer), prompt_txt, return_tensors='pt').to(self.device)
+                prompt = "Question: {} Answer:".format(prompt_txt)
+                encoding = self.processor(PIL.Image.open(image_buffer), prompt, return_tensors='pt').to(self.device)
                 output = self.model.generate(**encoding)
-                response = self.processor.decode(output[0], skip_special_tokens=True)
+                response = self.processor.decode(output[0], skip_special_tokens=True).strip()
                 print("Response: {}".format(response))
                 item_annotations.add(
                     annotation_definition=dl.FreeText(text=response),

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -5,13 +5,14 @@ import PIL
 import dtlpy as dl
 import logging
 from transformers import Blip2Processor, Blip2ForConditionalGeneration
+import torch
 
 logger = logging.getLogger("[BLIP-2]")
 
 class HuggingAdapter(dl.BaseModelAdapter):
     def load(self, local_path, **kwargs):
         self.model_name = self.configuration.get("model_name", "blip-2")
-        self.device = self.configuration.get("device", "cpu")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.conditioning = self.configuration.get("conditioning", False)
         self.processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 import torch
 import PIL
 import dtlpy as dl
@@ -57,7 +58,7 @@ class HuggingAdapter:
     def train(self, data_path, output_path, **kwargs):
         logger.info("Training not implemented yet")
 
-    def predict(self, batch: list[dl.Item], **kwargs):
+    def predict(self, batch: List[dl.Item], **kwargs):
         annotations = []
         for prompts in batch:
             item_annotations = dl.AnnotationCollection()

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -49,7 +49,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
             )
         return []
     
-    def get_last_user_message(messages):
+    def get_last_prompt_message(messages):
         for message in reversed(messages):
             if message.get("role") == "user":
                 return message
@@ -59,7 +59,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
         # In case of multiple messages, 
         # we assume the last user message contains the image of interest
 
-        last_user_message = HuggingAdapter.get_last_user_message(messages)
+        last_user_message = HuggingAdapter.get_last_prompt_message(messages)
         
         prompt_txt = None
         image_buffer = None

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -4,7 +4,7 @@ from typing import List
 import PIL
 import dtlpy as dl
 import logging
-from transformers import AutoProcessor, Blip2ForConditionalGeneration
+from transformers import Blip2Processor, Blip2ForConditionalGeneration
 
 logger = logging.getLogger("[BLIP-2]")
 
@@ -13,7 +13,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
         self.model_name = self.configuration.get("model_name", "blip-2")
         self.device = self.configuration.get("device", "cpu")
         self.conditioning = self.configuration.get("conditioning", False)
-        self.processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
+        self.processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model.to(self.device)
 

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -11,8 +11,8 @@ CAPTIONING_PROMPT = "Caption this image."
 
 class HuggingAdapter:
     def __init__(self, configuration):
-        self.model_name = configuration.get("model_name")
-        self.device = configuration.get("device")
+        self.model_name = configuration.get("model_name", "blip-2")
+        self.device = configuration.get("device", "cpu")
         self.conditioning = configuration.get("conditioning", False)
         self.processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
         self.model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
@@ -53,10 +53,7 @@ class HuggingAdapter:
                 raise ValueError(f"{prompt_key} is missing either an image or a text prompt.")
 
         return ready_prompts
-
-    def train(self, data_path, output_path, **kwargs):
-        logger.info("Training not implemented yet")
-
+    
     def predict(self, batch: List[dl.Item], **kwargs):
         annotations = []
         for prompts in batch:

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -1,6 +1,5 @@
 import json
 from typing import List
-import torch
 import PIL
 import dtlpy as dl
 import logging
@@ -41,8 +40,8 @@ class HuggingAdapter:
                     prompt_text = prompt_part["value"]
                     prompt_text_found = True
                 else:
-                    logger.warning(f"BLIP only accepts text and image prompts, "
-                                   f"ignoring the current prompt.")
+                    logger.warning("BLIP only accepts text and image prompts, "
+                                   "ignoring the current prompt.")
 
                 # Break loop after all inputs received
                 if prompt_image_found and prompt_text_found:

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -44,7 +44,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
                 model_info={
                     "name": self.model_name,
                     "confidence": 1.0,
-                    "model_id": '1',
+                    "model_id": self.model_entity.id,
                 },
             )
         return []

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -43,7 +43,7 @@ class HuggingAdapter:
                 model_info={
                     "name": self.model_name,
                     "confidence": 1.0,
-                    "model_id": self.model_entity.id,
+                    "model_id": 1,
                 },
             )
         return []

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -97,7 +97,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
             prompt_txt = "What is in this image?"
         prompt_txt = "Question: {} Answer:".format(prompt_txt)
 
-        if not image_buffer:
+        if image_buffer is None:
             raise ValueError("No image found in messages.")
 
         return prompt_txt, image_buffer

--- a/adapters/blip_2/blip_2.py
+++ b/adapters/blip_2/blip_2.py
@@ -47,7 +47,7 @@ class HuggingAdapter(dl.BaseModelAdapter):
                 model_info={
                     "name": self.model_name,
                     "confidence": 1.0,
-                    "model_id": 1,
+                    "model_id": self.model_entity.id,
                 },
             )
         return []

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -12,8 +12,12 @@
     },
     "displayName": "BLIP 2",
     "version": "0.1.45",
-    "scope": "project",
-
+    "scope": "public",
+    "codebase": {
+      "type": "git",
+      "gitUrl": "https://github.com/dataloop-ai-apps/huggingface-adapter.git",
+      "gitTag": "0.1.45"
+    },
     "components": {
       "computeConfigs": [
         {

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -2,7 +2,7 @@
     "name": "blip-2-huggingface-app",
     "description": "BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models",
     "attributes": {
-      "Provider": "Salesforce",
+      "Provider": "Hugging Face",
       "Deployed By": "Dataloop",
       "License": "BSD-3-Clause",
       "Category": "Model",

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -28,12 +28,10 @@
             "runnerImage": "gcr.io/viewo-g/piper/agent/runner/apps/huggingface-adapter:0.1.45",
             "concurrency": 1,
             "autoscaler": {
-              "type": "rabbitmq",
               "minReplicas": 0,
               "maxReplicas": 2,
               "queueLength": 1000
-            },
-            "preemptible": false
+            }
           }
         }
       ],

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -1,0 +1,112 @@
+{
+    "name": "blip-2-huggingface-app",
+    "description": "BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models",
+    "attributes": {
+      "Provider": "Salesforce",
+      "Deployed By": "Dataloop",
+      "License": "BSD-3-Clause",
+      "Category": "Model",
+      "NLP": "Conversational",
+      "Gen AI": "LMM",
+      "Media Type": ["Text", "Image", "Multi Modal"]
+    },
+    "displayName": "BLIP 2",
+    "version": "0.1.45",
+    "scope": "project",
+
+    "components": {
+      "computeConfigs": [
+        {
+          "name": "blip-2-huggingface-deploy",
+          "secrets": [],
+          "runtime": {
+            "podType": "regular-m",
+            "runnerImage": "dataloop_runner-gpu/huggingface-adapter:0.1.4",
+            "concurrency": 1,
+            "autoscaler": {
+              "type": "rabbitmq",
+              "minReplicas": 0,
+              "maxReplicas": 2,
+              "queueLength": 1000
+            },
+            "preemptible": false
+          }
+        }
+      ],
+      "modules": [
+        {
+          "name": "blip-2-module",
+          "entryPoint": "model_adapter.py",
+          "className": "ModelAdapter",
+          "computeConfig": "blip-2-huggingface-deploy",
+          "initInputs": [
+            {
+              "type": "Model",
+              "name": "model_entity"
+            }
+          ],
+          "functions": [
+            {
+              "name": "predict_items",
+              "input": [
+                {
+                  "type": "Item[]",
+                  "name": "items",
+                  "description": "The input images for prediction."
+                }
+              ],
+              "output": [
+                {
+                  "type": "Item[]",
+                  "name": "items",
+                  "description": "The same input images for prediction."
+                },
+                {
+                  "type": "Annotation[]",
+                  "name": "annotations",
+                  "description": "The predicted annotations."
+                }
+              ],
+              "displayName": "Predict Items",
+              "displayIcon": "",
+              "description": "The inference function of the model."
+            },
+            {
+              "name": "predict_dataset",
+              "input": [
+                {
+                  "type": "Dataset",
+                  "name": "dataset",
+                  "description": "The input dataset of the items required for prediction."
+                },
+                {
+                  "type": "Json",
+                  "name": "filters",
+                  "description": "The DQL in json format to get all the items required for prediction."
+                }
+              ],
+              "output": [],
+              "displayName": "Predict Dataset",
+              "displayIcon": "",
+              "description": "Inference function of the model on a dataset."
+            }
+          ]
+        }
+      ],
+      "models": [
+        {
+          "name": "blip-2-huggingface-model",
+          "moduleName": "blip-2-module",
+          "scope": "project",
+          "status": "pre-trained",
+          "configuration": {
+            "module_name": "adapters.blip_2.blip_2",
+            "device": "cpu",
+            "conditioning": false
+          },
+          "metadata": {},
+          "description": "BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models"
+        }
+      ]
+    }
+  }

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -106,7 +106,6 @@
           "configuration": {
             "model_name": "blip-2",
             "module_name": "adapters.blip_2.blip_2",
-            "device": "cpu",
             "conditioning": false
           },
           "metadata": {},

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -25,7 +25,7 @@
           "secrets": [],
           "runtime": {
             "podType": "regular-l",
-            "runnerImage": "dataloop_runner-gpu/huggingface-adapter:0.1.4",
+            "runnerImage": "gcr.io/viewo-g/piper/agent/runner/apps/huggingface-adapter:0.1.45",
             "concurrency": 1,
             "autoscaler": {
               "type": "rabbitmq",

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -41,7 +41,7 @@
         {
           "name": "blip-2-module",
           "entryPoint": "adapters/blip_2/blip_2.py",
-          "className": "ModelAdapter",
+          "className": "HuggingAdapter",
           "computeConfig": "blip-2-huggingface-deploy",
           "initInputs": [
             {

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -104,6 +104,7 @@
           "scope": "project",
           "status": "pre-trained",
           "configuration": {
+            "model_name": "blip-2",
             "module_name": "adapters.blip_2.blip_2",
             "device": "cpu",
             "conditioning": false

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -40,7 +40,7 @@
       "modules": [
         {
           "name": "blip-2-module",
-          "entryPoint": "model_adapter.py",
+          "entryPoint": "adapters/blip_2/blip_2.py",
           "className": "ModelAdapter",
           "computeConfig": "blip-2-huggingface-deploy",
           "initInputs": [

--- a/adapters/blip_2/dataloop.json
+++ b/adapters/blip_2/dataloop.json
@@ -24,7 +24,7 @@
           "name": "blip-2-huggingface-deploy",
           "secrets": [],
           "runtime": {
-            "podType": "regular-m",
+            "podType": "regular-l",
             "runnerImage": "dataloop_runner-gpu/huggingface-adapter:0.1.4",
             "concurrency": 1,
             "autoscaler": {

--- a/adapters/blip_image_captioning_large/blip_image_captioning_large.py
+++ b/adapters/blip_image_captioning_large/blip_image_captioning_large.py
@@ -51,12 +51,14 @@ class HuggingAdapter(dl.BaseModelAdapter):
             )
         return []
     
+    @staticmethod
     def get_last_prompt_message(messages):
         for message in reversed(messages):
             if message.get("role") == "user":
                 return message
         raise ValueError("No message with role 'user' found")
         
+    @staticmethod
     def reformat_messages(messages):
         # In case of multiple messages, 
         # we assume the last user message contains the image of interest

--- a/adapters/blip_image_captioning_large/dataloop.json
+++ b/adapters/blip_image_captioning_large/dataloop.json
@@ -2,7 +2,7 @@
   "name": "blip-image-captioning-large-huggingface-app",
   "description": "Bootstrapping Language-Image Pre-training for Unified Vision-Language Understanding and Generation",
   "attributes": {
-    "Provider": "Salesforce",
+    "Provider": "Hugging Face",
     "Deployed By": "Dataloop",
     "License": "BSD-3-Clause",
     "Category": "Model",


### PR DESCRIPTION
This pull request introduces a new adapter for the BLIP-2 model, including configuration, implementation, and integration with the existing system. The most important changes include adding the BLIP-2 adapter configuration, updating the `.dataloop.cfg` file, and implementing the BLIP-2 adapter class.

### BLIP-2 Adapter Configuration:
* Added the BLIP-2 adapter configuration file `adapters/blip_2/dataloop.json` to define the model's attributes, deployment details, and functions.

### Configuration Updates:
* Updated `.bumpversion.cfg` to include the BLIP-2 adapter in the version bumping process.
* Updated `.dataloop.cfg` to include the BLIP-2 adapter in the list of adapters.

### BLIP-2 Adapter Implementation:
* Implemented the BLIP-2 adapter class in `adapters/blip_2/blip_2.py`, including methods for preparing items, training (not yet implemented), and predicting annotations.